### PR TITLE
Add StockScope MCP to Company Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Legend: 📦 Open Source &nbsp;&middot;&nbsp; 🆓 Free / Has Free Tier &nbsp;&m
 ## Company Intelligence
 
 - 📦🆓💰 [CompanyScope](https://github.com/Stewyboy1990/companyscope-mcp) — Company intelligence aggregating data from 8 public sources (Wikipedia, SEC EDGAR, OpenCorporates, RDAP, GitHub, and more) for corporate reconnaissance. Free tier 25 calls/day, pay-per-use tier on Apify.
+- 📦🆓 [StockScope](https://github.com/Stewyboy1990/companyscope-mcp) — SEC EDGAR financial intelligence for stock research. Revenue, net income, margins, filings, and company comparisons for any US public company. Free, no API key needed.
 
 ## Threat Intelligence
 


### PR DESCRIPTION
Adds [StockScope MCP](https://www.npmjs.com/package/stockscope-mcp) to the Company Intelligence section.

**StockScope** provides SEC EDGAR financial intelligence for AI agents:
- `stock_financials` — Revenue, net income, assets, liabilities, equity, margins
- `stock_filings` — Recent 10-K, 10-Q, 8-K filings with document links
- `stock_compare` — Side-by-side financial comparison of two companies

Free, no API key needed. Works via `npx stockscope-mcp` or remote MCP endpoint.

Related to the already-listed CompanyScope MCP (same author, complementary toolset).