### PR TITLE
ContrastAPI: 25 → 29 tools (add orchestrated + bulk endpoints)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Legend: 📦 Open Source &nbsp;&middot;&nbsp; 🆓 Free / Has Free Tier &nbsp;&m
 - 📦🆓💰 [ZoomEye](https://github.com/zoomeye-ai/mcp_zoomeye) — Obtain network asset information by querying ZoomEye using dorks and other search parameters. 7-day free trial available, requires ZoomEye API key.
 - 📦🆓 [DNSTwist](https://github.com/BurtTheCoder/mcp-dnstwist) — DNS fuzzing tool that helps detect typosquatting, phishing, and corporate espionage.
 - 📦🆓 [OSINT Toolkit](https://www.pulsemcp.com/servers/himanshusanecha-osint-toolkit) — Unified interface for network reconnaissance with parallel execution of WHOIS, Nmap, DNS lookups, and typosquatting detection.
-- 📦🆓💰 [ContrastAPI](https://github.com/UPinar/contrastapi) — Security intelligence server with 25 tools: domain recon (DNS, WHOIS, SSL, subdomains, WAF, Wayback), IP reputation, CVE/EPSS/KEV lookup, IOC enrichment, threat intel, username OSINT, exploit search, and code security scanning. Free tier: 100 req/hr. Pro: 1000 req/hr with API key.
+- 📦🆓💰 [ContrastAPI](https://github.com/UPinar/contrastapi) — Security intelligence server with 29 tools: domain recon (DNS, WHOIS, SSL, subdomains, WAF, Wayback) plus orchestrated `audit_domain`, IP reputation plus orchestrated `threat_report` (Shodan + AbuseIPDB + ASN), CVE/EPSS/KEV lookup plus `bulk_cve_lookup` (50/call), IOC enrichment plus `bulk_ioc_lookup` (50/call), threat intel, username OSINT, exploit search, and code security scanning. Free tier: 100 req/hr. Pro: 1000 req/hr with API key.
 
 ## Web Scraping
 


### PR DESCRIPTION
## What

Updates the existing ContrastAPI entry to reflect the current 29-tool surface (was 25 when first added).

## Why

ContrastAPI added 4 tools since the original entry was merged:

- `audit_domain` — orchestrated full domain audit (domain report + tech fingerprint + live HTTP headers in one call, 4 credits)
- `threat_report` — orchestrated IP threat report (Shodan + AbuseIPDB + full Shodan + ASN in one call, 4 credits)
- `bulk_cve_lookup` — up to 50 CVE IDs in a single request
- `bulk_ioc_lookup` — up to 50 indicators (IP / domain / URL / hash) in a single request

## Diff

Single line, single file. Tool count `25 → 29` and inline category mentions for the four new tools. The existing emojis, link, ordering, and format are unchanged.

## Verification

- Live API: https://api.contrastcyber.com (free, no API key, 100 req/hr)
- Listed on the [Official MCP Registry](https://registry.modelcontextprotocol.io/v0/servers?search=contrastcyber) (DNS-verified) and Smithery (98/100)
- 844 tests passing, [open source](https://github.com/UPinar/contrastapi)
- Privacy transparency endpoint (returns every row the DB has about the caller): `curl https://api.contrastcyber.com/v1/privacy/my-data`