### PR TITLE
Add Not Human Search — meta-discovery for MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Legend: 📦 Open Source &nbsp;&middot;&nbsp; 🆓 Free / Has Free Tier &nbsp;&m
 - [Web Scraping](#web-scraping)
 - [Company Intelligence](#company-intelligence)
 - [Threat Intelligence](#threat-intelligence)
+- [Meta / Discovery](#meta--discovery)
 
 ## SOCMINT
 
@@ -52,6 +53,10 @@ Legend: 📦 Open Source &nbsp;&middot;&nbsp; 🆓 Free / Has Free Tier &nbsp;&m
 ## Threat Intelligence
 
 - 📦🆓 [VirusTotal](https://github.com/BurtTheCoder/mcp-virustotal) — Analyze URLs, files (by hash), IPs, and domains with detailed relationship mapping. Free API tier available, requires `VIRUSTOTAL_API_KEY`.
+
+## Meta / Discovery
+
+- 🆓 [Not Human Search](https://nothumansearch.ai) — Agent-first discovery engine for MCP servers. Search, score, and live-probe (`verify_mcp`) 8,600+ servers via JSON-RPC or REST API. Useful for pivoting between OSINT MCP tools. MCP: https://nothumansearch.ai/mcp
 
 ## Contributing
 


### PR DESCRIPTION
Adds [Not Human Search](https://nothumansearch.ai) under a new **Meta / Discovery** section.

NHS is an agent-first discovery engine that indexes and live-probes 8,600+ MCP servers. For OSINT investigators who work across multiple MCP tools, NHS helps find and verify servers by capability — e.g. searching for "whois", "dns", "threat intel" surfaces matching MCP servers with agentic-readiness scores and a `verify_mcp` JSON-RPC probe to confirm they're reachable before wiring them into a workflow.

**Tools exposed via MCP** (https://nothumansearch.ai/mcp):
- `search` — query the index by keyword + category
- `verify_mcp` — live JSON-RPC probe of any MCP endpoint
- `get_site_details`, `list_categories`, `get_top_sites`, and 3 more

Free, no API key. REST API also available at `/api/v1/*`.

Placed in a new **Meta / Discovery** section since it's a directory/verifier rather than an OSINT source itself — happy to move it if you'd prefer a different spot.