### PR TITLE
Add Voidly — global censorship intelligence MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Legend: 📦 Open Source &nbsp;&middot;&nbsp; 🆓 Free / Has Free Tier &nbsp;&m
 ## Threat Intelligence
 
 - 📦🆓 [VirusTotal](https://github.com/BurtTheCoder/mcp-virustotal) — Analyze URLs, files (by hash), IPs, and domains with detailed relationship mapping. Free API tier available, requires `VIRUSTOTAL_API_KEY`.
+- 📦🆓 [Voidly](https://www.npmjs.com/package/@voidly/mcp-server) — Global internet censorship intelligence: 116 tools across 119+ countries. Query OONI / IODA / CensoredPlanet evidence, look up 5,356 citable incidents, check if a domain or service is blocked in a country, fetch ISP-level risk scores, run ML-driven shutdown forecasts, and verify censorship claims. Free, no API key needed for read endpoints. `npx @voidly/mcp-server`.
 
 ## Meta / Discovery
 


### PR DESCRIPTION
Adds [Voidly](https://www.npmjs.com/package/@voidly/mcp-server) under **Threat Intelligence**.

Voidly's MCP server is a strong fit for OSINT workflows that involve nation-state network interference: 116 tools cover 119+ countries with OONI / IODA / CensoredPlanet evidence, 5,356 citable incidents (`IR-2026-0142` style IDs), domain accessibility checks, ISP-level risk scoring, and ML-driven shutdown forecasting. Investigators can pivot from a username or company to "is this service reachable from Iran right now, and what ISPs are blocking it?" without leaving Claude/Cursor/Windsurf. Read endpoints are free and require no API key.

Entry placed alphabetically (V after VirusTotal) in the Threat Intelligence section.

maintainer: @EmperorMew