### PR TITLE
feat: add The Stall to Blockchain Intelligence (OFAC sanctions screening, wallet OSINT, x402)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Legend: 📦 Open Source &nbsp;&middot;&nbsp; 🆓 Free / Has Free Tier &nbsp;&m
 ## Blockchain Intelligence
 
 - 💰 [TWZRD Agent Intel](https://intel.twzrd.xyz) — Blockchain OSINT for AI agent trust scoring — reads public Solana on-chain data (wallet history, transaction patterns) to score agent trustworthiness. Free preflight + paid signed V5 trust receipts via x402 micropayments. MCP: https://intel.twzrd.xyz/mcp
+- 💰 [The Stall](https://github.com/thebrierfox/the-stall) — Multi-tool blockchain OSINT server: OFAC sanctions screening (19,000+ SDN entries, fuzzy name match + AKA aliases), wallet risk scoring, agent KYA trust scoring, EVM and Solana transaction intelligence, and token security analysis. Pay-per-call via x402 USDC micropayments on Base — no accounts or API keys. MCP: https://the-stall.intuitek.ai/mcp
 
 ## Contributing
 


### PR DESCRIPTION
## What

Adds **[The Stall](https://github.com/thebrierfox/the-stall)** to the **Blockchain Intelligence** section.

The Stall is a pay-per-call MCP server with a dedicated blockchain OSINT suite:

| Tool | Source | Description |
|------|--------|-------------|
| `sanctions-screening` | OFAC SDN Treasury | 19,000+ SDN entries, F1 fuzzy name match + AKA aliases |
| `wallet-screener` | Multi-chain | Wallet risk scoring: tx patterns, age, mixing history |
| `wallet-credit-score` | AsterPay KYA | Creditworthiness score for agent/wallet pairs |
| `agent-kya-score` | AsterPay | Trust score, sanctions check, attestations, spending limits |
| `address-security` | EVM | Address risk classification |
| `tx-explainer` | EVM | Human-readable EVM transaction decoding |
| `solana-tx-explainer` | Solana mainnet | Solana transaction intelligence with token deltas |
| `solana-token-risk` | Multi-source | Solana token contract risk flags |

**Payment model:** x402 USDC micropayments on Base — no accounts or API keys needed for agents.

**MCP endpoint:** https://the-stall.intuitek.ai/mcp