### PR TITLE
Add DataNexus MCP — public records intelligence (domain, patents, GovCon, regulatory, nonprofits, CVEs, compliance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Legend: 📦 Open Source &nbsp;&middot;&nbsp; 🆓 Free / Has Free Tier &nbsp;&m
 - [Network Scanning](#network-scanning)
 - [Web Scraping](#web-scraping)
 - [Company Intelligence](#company-intelligence)
+- [Public Records & Compliance](#public-records--compliance)
 - [Threat Intelligence](#threat-intelligence)
 - [Research Intelligence](#research-intelligence)
 - [Meta / Discovery](#meta--discovery)
@@ -54,6 +55,10 @@ Legend: 📦 Open Source &nbsp;&middot;&nbsp; 🆓 Free / Has Free Tier &nbsp;&m
 - 📦💰 [US Business Data](https://github.com/avabuildsdata/mcp-us-business-data) — Search Secretary of State business registrations across 17 US states, building permits in 400+ cities, and Yellow Pages business leads. Returns entity details, filing status, and registered agents.
 - 🆓💰 [OpenRegistry](https://github.com/sophymarine/openregistry) — Real-time access to 27 national corporate registries worldwide (UK Companies House, France Sirene, Germany Handelsregister, South Korea OPENDART, Australia ABR, Canada Corporations, etc.) via a unified JSON schema. Returns company profiles, officers, shareholders, beneficial ownership, filings, and raw documents. Free tier: 20 rpm without signup, 30 rpm with email. Paid up to $29/mo. OAuth 2.1, no API keys.
 - 📦💰 [Checko MCP](https://github.com/Nymaxxx/checko-mcp) — Unofficial wrapper for the Russian Checko.ru API: verify counterparties (companies, sole proprietors, individuals) via EGRUL/EGRIP, arbitration cases, government contracts (44-FZ/223-FZ), Rosstat financials, inspections, Fedresurs and EFRSB bankruptcy records. 12 tools and 6 ready-made workflow prompts. Requires paid `CHECKO_API_KEY`.
+
+## Public Records & Compliance
+
+- 🆓💰 [DataNexus MCP](https://smithery.ai/servers/dev-7bd0/mcp-server/) — Public records intelligence across 7 domains: domain recon (RDAP, DNS, SSL, subdomains, email security), patent search & inventor portfolios (EPO/WIPO), US government contract awards & vendor history (SAM.gov), regulatory filings & dockets (Regulations.gov + Federal Register), US/UK nonprofit 990 data & health scores, CVE/SBOM/EPSS vulnerability intelligence, and professional licence verification (NPI, FINRA, SAM exclusions). 55 tools, no API key required for free tier, hosted remote MCP.
 
 ## Threat Intelligence
 


### PR DESCRIPTION
DataNexus MCP adds public records coverage that isn't currently represented in the list:

- Government contract awards & vendor history (SAM.gov)
- Patent search & inventor portfolios (EPO/WIPO)
- Regulatory filings & dockets (Regulations.gov)
- US/UK nonprofit 990 data with health scoring
- Professional licence verification (NPI, FINRA, SAM exclusions)
- Domain recon (RDAP, DNS, SSL, subdomains, email security)
- CVE/SBOM/EPSS vulnerability intelligence

55 tools. Free tier requires no API key. Hosted remote MCP — one-click via Smithery: https://smithery.ai/servers/dev-7bd0/mcp-server/

Licence is BSL 1.1 (source available, not OSI open source) — tagged 🆓💰 accordingly.

I've placed it in a new **Public Records & Compliance** section rather than Company Intelligence, since patents, GovCon, regulatory filings, and NPI/FINRA compliance don't fit the existing categories.