### PR TITLE
Add BuyWhere MCP server to Market & Trading section

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Legend: 📦 Open Source &nbsp;&middot;&nbsp; 🆓 Free / Has Free Tier &nbsp;&m
 
 - 📦🆓💰 [Helium MCP](https://github.com/connerlambden/helium-mcp) — 37-dimensional news bias scoring across 216 sources, market data, and ML options pricing. Remote MCP + REST. [Demo](https://connerlambden.github.io/helium-news-explorer/) · [docs](https://heliumtrades.com/mcp-page/)
 
+- 📦🆓 [BuyWhere](https://github.com/BuyWhere/buywhere-mcp) — Real-time cross-border e-commerce product search and price comparison across 11M+ items from 50+ stores (Amazon, Lazada, Shopee). MCP server for AI-powered shopping agents.
+
 ## Contributing
 
 Contributions are welcome! Please open a pull request to add a new OSINT MCP server to the list.


### PR DESCRIPTION
## Summary

Adds [BuyWhere](https://github.com/BuyWhere/buywhere-mcp) to the Market & Trading section.

**BuyWhere** is a real-time cross-border e-commerce MCP server providing product search and price comparison across 11M+ items from 50+ stores (Amazon, Lazada, Shopee, etc.).

## Why it fits

- **Market & Trading**: BuyWhere enables AI agents to search real-time product pricing data, compare prices across retailers, and find deals — useful for market intelligence and price tracking use cases.
- **Already listed on 17+ directories** including PulseMCP, mcp.so, Smithery, Glama, and the official MCP Registry.
- **Open source**: https://github.com/BuyWhere/buywhere-mcp
- **Remote MCP server**: https://mcp.buywhere.ai

## Entry

```markdown
- 📦🆓 [BuyWhere](https://github.com/BuyWhere/buywhere-mcp) — Real-time cross-border e-commerce product search and price comparison across 11M+ items from 50+ stores (Amazon, Lazada, Shopee). MCP server for AI-powered shopping agents.
```