### PR TITLE
Add osint-agent-skills to Threat Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Legend: 📦 Open Source &nbsp;&middot;&nbsp; 🆓 Free / Has Free Tier &nbsp;&m
 - 📦🆓 [VirusTotal](https://github.com/BurtTheCoder/mcp-virustotal) — Analyze URLs, files (by hash), IPs, and domains with detailed relationship mapping. Free API tier available, requires `VIRUSTOTAL_API_KEY`.
 - 📦🆓 [Voidly](https://www.npmjs.com/package/@voidly/mcp-server) — Global internet censorship intelligence: 116 tools across 119+ countries. Query OONI / IODA / CensoredPlanet evidence, look up 5,356 citable incidents, check if a domain or service is blocked in a country, fetch ISP-level risk scores, run ML-driven shutdown forecasts, and verify censorship claims. Free, no API key needed for read endpoints. `npx @voidly/mcp-server`.
 - 📦🆓 [OpenOSINT](https://github.com/OpenOSINT/OpenOSINT) — AI-powered OSINT agent with interactive REPL, MCP server, and CLI.
+- 📦🆓 [osint-agent-skills](https://github.com/frangelbarrera/osint-agent-skills) — 23 MCP tools (DNS, Shodan InternetDB, crt.sh, Wayback CDX, GitHub code search, OTX, HIBP, Etherscan, Mastodon) with zero-dependency Node.js server for Claude Code, Cursor, and Ollama.
 
 ## Research Intelligence
 


### PR DESCRIPTION
## What

Adding [osint-agent-skills](https://github.com/frangelbarrera/osint-agent-skills) to the **Threat Intelligence** section, grouped with `OpenOSINT` (similar profile: OSINT agent with MCP server).

## Why

osint-agent-skills is a zero-dependency Node.js MCP server exposing 23 OSINT tools, designed for use with Claude Code, Cursor, Ollama, and any MCP-compatible client:

- **DNS / Domain**: `dns_lookup`, `rdap_lookup_domain`, `rdap_lookup_ip`, `crt_sh_search`
- **Web history**: `wayback_cdx`, `wayback_save`
- **Network recon**: `shodan_internetdb`, `shodan_host_lookup`, `ipinfo_lookup`, `bgpview_asn`, `urlscan_search`
- **Code & identity**: `github_user_lookup`, `github_code_search`, `gravatar_lookup`
- **Threat intel**: `alienvault_otx_lookup`, `virustotal_domain_report`, `hibp_breach_check`, `securitytrails_history`
- **OSINT pivots**: `hunter_email_finder`, `nominatim_geocode`
- **Blockchain**: `blockchain_address_lookup`, `etherscan_address_lookup`
- **Social**: `mastodon_user_lookup`

~15 of the 23 tools work with no API key. The remaining 7 accept free-tier keys (VT, Etherscan) or paid keys (Shodan full / SecurityTrails / Hunter / HIBP). MIT licensed, no runtime dependencies.

## Self-promotion disclosure

I am the author of osint-agent-skills. Happy to remove or adjust if it doesn't fit the curation criteria.

## Format check

- ✅ Format: `- 📦🆓 [Name](url) — description.` (matches existing entries)
- ✅ Section: Threat Intelligence (grouped with OpenOSINT — similar OSINT-agent-with-MCP profile)
- ✅ Individual PR