### PR TITLE
Add AgentServices — x402 crypto market data & intelligence APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Legend: 📦 Open Source &nbsp;&middot;&nbsp; 🆓 Free / Has Free Tier &nbsp;&m
 ## Market & Trading
 
 - 📦🆓💰 [Helium MCP](https://github.com/connerlambden/helium-mcp) — 37-dimensional news bias scoring across 216 sources, market data, and ML options pricing. Remote MCP + REST. [Demo](https://connerlambden.github.io/helium-news-explorer/) · [docs](https://heliumtrades.com/mcp-page/)
+- 📦💰 [AgentServices](https://agentservices.to) — x402-paid crypto market data and intelligence APIs for AI agents. 54 services, 97 endpoints, 37 MCP tools. Live prices, DeFi data, on-chain analytics, fear-greed index. MCP: https://api.agentservices.to/mcp
 
 ## Contributing
 


### PR DESCRIPTION
## AgentServices

**Website:** https://agentservices.to
**MCP Server:** https://api.agentservices.to/mcp
**GitHub:** https://github.com/vbkotecha/aiservices-api

### What

AgentServices provides x402-paid crypto market data and intelligence APIs for AI agents. Agents pay per-request using USDC on Base via HTTP 402 — no API keys, no signups.

- **54 services** | **97 endpoints** (41 x402-paid) | **37 MCP tools**
- On-chain analytics, DeFi data, live prices, fear-greed index
- Listed on official MCP Registry: `to.agentservices/agentservices`

### Placement

Adding to **Market & Trading** section alongside Helium MCP — both are market data servers with remote MCP + REST access.

### Links verified
- ✅ https://agentservices.to (200 OK)
- ✅ https://api.agentservices.to/mcp (MCP handshake confirmed)
- ✅ x402 payment live (HTTP 402 → USDC on Base)