### PR TITLE
Add Claudii Exploratores — 898-tool OSINT suite (Agent Skill + MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Legend: 📦 Open Source &nbsp;&middot;&nbsp; 🆓 Free / Has Free Tier &nbsp;&m
 ## Meta / Discovery
 
 - 🆓 [Not Human Search](https://nothumansearch.ai) — Agent-first discovery engine for MCP servers. Search, score, and live-probe (`verify_mcp`) 8,600+ servers via JSON-RPC or REST API. Useful for pivoting between OSINT MCP tools. MCP: https://nothumansearch.ai/mcp
+- 📦🆓 [Claudii Exploratores](https://github.com/SOsintOps/claudii-exploratores) — OSINT suite exposing 898 curated OSINT tools across 24 categories (people, usernames, email, domains, IP, phones, companies, crypto, IBAN, media, social platforms…) as both a Claude Agent Skill and an MCP server. Auto-classifies an indicator, builds only the search URLs that fit it, and includes an offline ISO 13616 IBAN verifier and a reversible PII redactor. Python / FastMCP, AGPL-3.0. Alpha.
 
 ## Blockchain Intelligence
 


### PR DESCRIPTION
Adds **Claudii Exploratores** to the **Meta / Discovery** section.

Closes #51.

Ported OSINT toolkit that exposes 898 curated OSINT tools across 24 categories (people, usernames, email, domains, IP, phones, companies, crypto, IBAN, media, social platforms, etc.) as both a Claude Agent Skill and an MCP server (Python / FastMCP). It classifies an incoming indicator, then builds only the search URLs that fit it — instead of dumping all 898 — plus an offline ISO 13616 IBAN verifier and a reversible PII redactor for sending case text to external models.

- Repo: https://github.com/SOsintOps/claudii-exploratores
- License: AGPL-3.0
- Status: alpha

Placed in Meta / Discovery next to Not Human Search, since both are OSINT-tool aggregators rather than a single-source integration.