### PR TITLE
Add Nummeropslag MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Legend: 📦 Open Source &nbsp;&middot;&nbsp; 🆓 Free / Has Free Tier &nbsp;&m
 ## Public Records & Compliance
 
 - 🆓💰 [DataNexus MCP](https://smithery.ai/servers/dev-7bd0/mcp-server/) — Public records intelligence across 7 domains: domain recon (RDAP, DNS, SSL, subdomains, email security), patent search & inventor portfolios (EPO/WIPO), US government contract awards & vendor history (SAM.gov), regulatory filings & dockets (Regulations.gov + Federal Register), US/UK nonprofit 990 data & health scores, CVE/SBOM/EPSS vulnerability intelligence, and professional licence verification (NPI, FINRA, SAM exclusions). 55 tools, no API key required for free tier, hosted remote MCP.
+- 📦💰 [Nummeropslag](https://github.com/andrey-tut/nummeropslag-api) — Privacy-first Danish phone-number intelligence using official CVR and telecom-register data. Look up registered companies, operators, number types, and community spam/trust signals without exposing private individuals' names. Requires a paid API key.
 
 ## Threat Intelligence
 


### PR DESCRIPTION
## What changed

Adds Nummeropslag to Public Records & Compliance.

## Why

Nummeropslag provides a narrow, privacy-first OSINT capability for Danish phone numbers: official CVR-registered companies, telecom operators and number types, and community spam/trust signals. It explicitly does not expose names of private individuals.

The linked repository contains the open-source MCP server, setup instructions, and the underlying OpenAPI contract.

## Validation

- Confirmed the API source and paid-key requirement
- Confirmed the privacy limitation in the service and repository documentation
- Ran `python3 -m py_compile mcp/server.py`
- Ran `git diff --check`
