### PR TITLE
Add SkillsIndex to Meta / Discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Legend: 📦 Open Source &nbsp;&middot;&nbsp; 🆓 Free / Has Free Tier &nbsp;&m
 
 - 🆓 [Not Human Search](https://nothumansearch.ai) — Agent-first discovery engine for MCP servers. Search, score, and live-probe (`verify_mcp`) 8,600+ servers via JSON-RPC or REST API. Useful for pivoting between OSINT MCP tools. MCP: https://nothumansearch.ai/mcp
 - 📦🆓 [Claudii Exploratores](https://github.com/SOsintOps/claudii-exploratores) — OSINT suite exposing 898 curated OSINT tools across 24 categories (people, usernames, email, domains, IP, phones, companies, crypto, IBAN, media, social platforms…) as both a Claude Agent Skill and an MCP server. Auto-classifies an indicator, builds only the search URLs that fit it, and includes an offline ISO 13616 IBAN verifier and a reversible PII redactor. Python / FastMCP, AGPL-3.0. Alpha.
+- 🆓 [SkillsIndex](https://skillsindex.dev) - Search and vetting index for 11,651 MCP servers, Claude skills, GPT actions and IDE plugins, including the OSINT servers listed here. Every entry carries a 0-100 score built from separate security, utility and maintenance ratings, so a server can be checked before it is installed ([method](https://skillsindex.dev/methodology/)). Agent-native search through its own MCP server, [skillsindex-mcp](https://github.com/thomasblc/skillsindex-mcp) (`search_tools`, `check_security`, `get_top_rated`).
 
 ## Blockchain Intelligence
 


### PR DESCRIPTION
Adds SkillsIndex to **Meta / Discovery**, alongside Not Human Search and Claudii Exploratores.

Disclosure: I run it.

Why it fits this section: it is a searchable index of 11,651 MCP servers, Claude skills, GPT actions and IDE plugins, and each entry carries a 0-100 score assembled from separate security, utility and maintenance ratings, so a server can be looked up and checked before it is installed. Servers already in this list are covered (mcp-maigret, shodan, sherlock-mcp, plus Claude-OSINT as a skill). There is also an MCP server for agent-native lookups, `skillsindex-mcp` (`search_tools`, `check_security`, `get_top_rated`), published on npm and in the official MCP registry.

Two notes on the entry itself:
- I used the free-tier emoji only, not the open-source one: the site is free to use, but the repo behind it is not public, so the open-source flag would be wrong.
- I wrote the separator as a plain hyphen rather than an em dash. Happy to match the surrounding style if you prefer, or to trim the description; the entry runs a little long next to the shorter ones.

+1 / -0, no other changes.
