### PR TITLE
Add 7 OSINT MCP servers across 5 sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Legend: 📦 Open Source &nbsp;&middot;&nbsp; 🆓 Free / Has Free Tier &nbsp;&m
 - 💰 [Expose Team](https://expose.team?utm_source=github.com&utm_campaign=soxoj_awesome_osint_mcp_servers) — AI-powered OSINT at lightspeed. Credit-based plans from $8/month.
 - 📦🆓 [Maigret](https://github.com/BurtTheCoder/mcp-maigret) — Collect user account information from various public sources by username.
 - 📦💰 [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) — X (Twitter) data extraction and automation with 40+ REST API endpoints, real-time account monitoring, and trending topics. MCP server with API key auth.
+- 📦🆓 [OSINT Tools MCP](https://github.com/frishtik/osint-tools-mcp-server) — Wraps seven classic OSINT CLIs behind one server: Sherlock and Blackbird (usernames), Maigret, Holehe (email), GHunt (Google accounts), theHarvester (domains) and SpiderFoot. Python, installs the underlying tools itself.
+- 📦🆓 [LinkedIn MCP](https://github.com/eliasbiondo/linkedin-mcp-server) — Search LinkedIn people, companies and jobs, and pull structured profile, company and post data. Uses your own session cookie; no API key.
 
 ## Network Scanning
 
@@ -45,11 +47,14 @@ Legend: 📦 Open Source &nbsp;&middot;&nbsp; 🆓 Free / Has Free Tier &nbsp;&m
 - 🆓💰 [DomScan](https://domscan.net) — Domain intelligence with DNS, WHOIS/RDAP, SSL/TLS, subdomain enumeration, certificate search, typosquatting and brand monitoring, plus domain valuation and availability. One API and MCP server; free tools with paid API tiers.
 - 🆓💰 [CrawlGraph](https://github.com/pucilpet/crawlgraph-mcp) — Passive web footprinting via the Common Crawl webgraph - mapping which sites reference a target, without ever touching the target (passive, no active scanning). Two tools for OSINT research: inbound linking to target and link-gap between two or more targets. `npx -y crawlgraph-mcp`. Free sign up for 15 targets/mo ; paid lifetime API for higher limits and link-gap research.
 - 🆓💰 [DomainKits](https://domainkits.com/dev?utm_source=github&utm_campaign=awesome-osint-mcp) — Search newly registered, expired, and dropped domains across gTLDs for phishing, typosquatting, and brand-impersonation monitoring, with WHOIS, DNS, reverse-nameserver, IP geolocation, and Google Safe Browsing lookups. Requires paid API key.
+- 📦🆓 [IPInfo](https://github.com/briandconnelly/mcp-server-ipinfo) — IP geolocation, ASN and network details, Tor exit-node checks, and interactive maps for sets of IPs via ipinfo.io. Free API token required.
+
 ## Web Scraping
 
 - 🆓💰 [AnySite](https://docs.anysite.io/mcp-server/overview) — Structured data access to 115+ endpoints across 40+ platforms (LinkedIn, Instagram, X, Reddit, YouTube, GitHub, Amazon, etc.) via five meta-tools. 7-day free trial with 1,000 credits.
 - 📦🆓💰 [Bright Data](https://github.com/brightdata/brightdata-mcp) — Real-time web search, scraping, and structured data extraction from 60+ sources (Amazon, LinkedIn, TikTok, Google Maps, etc.) with CAPTCHA and anti-bot bypass. Free tier: 5,000 requests/month.
 - 🆓💰 [Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) — Web search and page-content extraction (`web_search`, `web_fetch`) for LLM agents. Default endpoint works without an API key; an account with credits is needed for production rate limits. MCP: https://search.parallel.ai/mcp
+- 📦🆓 [Wayback Machine MCP](https://github.com/Mearman/mcp-wayback-machine) — Query and save Internet Archive snapshots: check archive status, fetch archived URLs, search the CDX index, and compare two snapshots of a page. No API key for reads. `npx -y mcp-wayback-machine`
 
 ## Company Intelligence
 
@@ -60,6 +65,7 @@ Legend: 📦 Open Source &nbsp;&middot;&nbsp; 🆓 Free / Has Free Tier &nbsp;&m
 - 🆓💰 [OpenRegistry](https://github.com/sophymarine/openregistry) — Real-time access to 27 national corporate registries worldwide (UK Companies House, France Sirene, Germany Handelsregister, South Korea OPENDART, Australia ABR, Canada Corporations, etc.) via a unified JSON schema. Returns company profiles, officers, shareholders, beneficial ownership, filings, and raw documents. Free tier: 20 rpm without signup, 30 rpm with email. Paid up to $29/mo. OAuth 2.1, no API keys.
 - 📦💰 [Checko MCP](https://github.com/Nymaxxx/checko-mcp) — Unofficial wrapper for the Russian Checko.ru API: verify counterparties (companies, sole proprietors, individuals) via EGRUL/EGRIP, arbitration cases, government contracts (44-FZ/223-FZ), Rosstat financials, inspections, Fedresurs and EFRSB bankruptcy records. 12 tools and 6 ready-made workflow prompts. Requires paid `CHECKO_API_KEY`.
 - 🆓 [Fylings](https://github.com/HeyZod/fylings-mcp) — African company intelligence across 18+ official national registries (Nigeria's CAC, Tanzania's BRELA, Mauritius's CBRD, Senegal's RCCM, and more) via a unified schema, with the official registry source and a last-verified date on every record. Company search & verification, beneficial ownership, government-contract awards, and sanctions screening. Free, no API key. Hosted MCP: https://www.fylings.com/api/mcp
+- 📦🆓 [Companies House MCP](https://github.com/stefanoamorelli/companies-house-mcp) — 38 tools over the UK Companies House API: company and officer search, profiles, filing history and documents, charges, insolvency, PSC/beneficial ownership and disqualifications. Free API key required. AGPL-3.0.
 
 ## Public Records & Compliance
 
@@ -75,6 +81,8 @@ Legend: 📦 Open Source &nbsp;&middot;&nbsp; 🆓 Free / Has Free Tier &nbsp;&m
 - 📦🆓 [VulneraMCP](https://github.com/telmon95/VulneraMCP) — AI-powered bug bounty MCP server with recon (subfinder, httpx, gau, ffuf), vulnerability testing (XSS/SQLi/IDOR/CSRF), API/auth/cloud scanning, knowledge-graph analysis, and Markdown reporting. Integrates OWASP ZAP and CLI tools with PostgreSQL storage.
 - 📦🆓 [Clearfront](https://github.com/scottmartinanderson/clearfront) — Self-OSINT footprint scanner exposing 30 tools over MCP: username enumeration (Sherlock, Maigret, WhatsMyName), email and breach checks (holehe, HIBP, Hudson Rock infostealer logs), domain and IP recon (crt.sh, Shodan, Censys, GreyNoise, Wayback Machine), and EXIF/GPS extraction. Correlates findings into an evidence graph and rates each by source, confidence and severity. Configurable sweep depth and a local web console. `pip install clearfront`, runs locally, most tools keyless.
 - 📦🆓 [ScanMalware](https://github.com/scanmalware/mcp-server) — Submit a URL for sandboxed browser analysis, then pivot across the scan archive: search by domain, IP, ASN, JARM, favicon mmh3, TLSH/ssdeep fuzzy hash, screenshot hash, OCR text, or JavaScript fingerprint. Also exposes YARA matches, TLS/RDAP records, Certificate Transparency pivots, detected technologies, and pastejacking/clipboard events. 128 tools, no API key required. MCP: https://mcp.scanmalware.com/mcp
+- 📦🆓 [Darknet MCP](https://github.com/badchars/darknet-mcp-server) — 66 tools for dark web and breach intelligence: ransomware group tracking and victim listings, stealer logs, HIBP breach lookups, IntelX search, Tor .onion fetching and exit-node checks, MalwareBazaar/ThreatFox/URLhaus feeds, and Bitcoin address intel. Many tools work with no API key; premium sources unlock with your own keys. `npx darknet-mcp-server`
+- 📦🆓 [OpenCTI MCP](https://github.com/zxzinn/opencti-mcp) — Natural-language access to an OpenCTI instance: latest reports, campaigns by name, attack patterns, indicators, labels and marking definitions over the GraphQL API. Requires your own OpenCTI URL and token.
 
 ## Research Intelligence
 


### PR DESCRIPTION
Seven servers found by sweeping GitHub, each checked the way CONTRIBUTING describes — real code, tools actually registered, working `bin` where an npm package is claimed, license and activity.

**SOCMINT**
- [OSINT Tools MCP](https://github.com/frishtik/osint-tools-mcp-server) — stdio server wrapping Sherlock, Blackbird, Maigret, Holehe, GHunt, theHarvester, SpiderFoot.
- [LinkedIn MCP](https://github.com/eliasbiondo/linkedin-mcp-server) — people/company/job search and profile scraping via your own session cookie.

**Network Scanning**
- [IPInfo](https://github.com/briandconnelly/mcp-server-ipinfo) — geolocation, ASN, Tor exit-node checks, maps for IP sets.

**Web Scraping**
- [Wayback Machine MCP](https://github.com/Mearman/mcp-wayback-machine) — archive status, archived URLs, CDX search, snapshot diffing. Keyless for reads.

**Company Intelligence**
- [Companies House MCP](https://github.com/stefanoamorelli/companies-house-mcp) — 38 tools over the UK registry, including PSC/beneficial ownership and disqualifications.

**Threat Intelligence**
- [Darknet MCP](https://github.com/badchars/darknet-mcp-server) — 66 tools: ransomware victim tracking, stealer logs, IntelX, Tor .onion access, abuse.ch feeds.
- [OpenCTI MCP](https://github.com/zxzinn/opencti-mcp) — GraphQL access to a self-hosted OpenCTI instance.

Verification notes: the three npm-published entries (Darknet MCP, Wayback Machine MCP, Companies House MCP) have working `bin` entries and non-empty `dist`; tool counts were counted in the published bundle rather than taken from the README — Darknet MCP's claimed 66 and Companies House's 38 both match exactly. `nickpending/mcp-censys` was dropped as archived, and duplicate Shodan/VirusTotal wrappers were skipped since both tools are already listed.

Also adds the blank line that was missing before the Web Scraping heading.

Not included, open for discussion: `stass/exif-mcp` (good, keyless EXIF/XMP/GPS extraction, but no section fits and a one-entry section seems worse), `MorDavid/ExternalAttacker-MCP` (no license, a year stale), `mukul975/Malware-Sandbox-mcp` (overlaps ScanMalware).
