### PR TITLE
Add StackScan to Network Scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Legend: 📦 Open Source &nbsp;&middot;&nbsp; 🆓 Free / Has Free Tier &nbsp;&m
 - 🆓💰 [CrawlGraph](https://github.com/pucilpet/crawlgraph-mcp) — Passive web footprinting via the Common Crawl webgraph - mapping which sites reference a target, without ever touching the target (passive, no active scanning). Two tools for OSINT research: inbound linking to target and link-gap between two or more targets. `npx -y crawlgraph-mcp`. Free sign up for 15 targets/mo ; paid lifetime API for higher limits and link-gap research.
 - 🆓💰 [DomainKits](https://domainkits.com/dev?utm_source=github&utm_campaign=awesome-osint-mcp) — Search newly registered, expired, and dropped domains across gTLDs for phishing, typosquatting, and brand-impersonation monitoring, with WHOIS, DNS, reverse-nameserver, IP geolocation, and Google Safe Browsing lookups. Requires paid API key.
 - 📦🆓 [IPInfo](https://github.com/briandconnelly/mcp-server-ipinfo) — IP geolocation, ASN and network details, Tor exit-node checks, and interactive maps for sets of IPs via ipinfo.io. Free API token required.
+- 📦💰 [StackScan](https://github.com/stackscan/stackscan-mcp) — Technographic lookups over 360M+ sites: what a domain is built on, who is behind it (industry, city, country, LinkedIn), and how many sites run a given technology and where. Batch domain lookup for list enrichment. Local stdio server, MIT, `npx @stackscan/mcp-server`. Charged per resolving domain; misses are not charged and `check_credits` is free.
 
 ## Web Scraping
 


### PR DESCRIPTION
Adds StackScan to **Network Scanning**.

**Disclosure: I work on StackScan.**

MCP server for the StackScan Tech Lookup API: what a domain is built on, who is behind it (industry, city, country, LinkedIn), how many sites run a given technology and where, plus batch domain lookup for enriching a list.

Local stdio process launched with npx, MIT, source at https://github.com/stackscan/stackscan-mcp. Charged per resolving domain; misses are not charged and `check_credits` is free.