### PR TITLE
Add BulkTranscripts to SOCMINT

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Legend: 📦 Open Source &nbsp;&middot;&nbsp; 🆓 Free / Has Free Tier &nbsp;&m
 - 📦💰 [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) — X (Twitter) data extraction and automation with 40+ REST API endpoints, real-time account monitoring, and trending topics. MCP server with API key auth.
 - 📦🆓 [OSINT Tools MCP](https://github.com/frishtik/osint-tools-mcp-server) — Wraps seven classic OSINT CLIs behind one server: Sherlock and Blackbird (usernames), Maigret, Holehe (email), GHunt (Google accounts), theHarvester (domains) and SpiderFoot. Python, installs the underlying tools itself.
 - 📦🆓 [LinkedIn MCP](https://github.com/eliasbiondo/linkedin-mcp-server) — Search LinkedIn people, companies and jobs, and pull structured profile, company and post data. Uses your own session cookie; no API key.
-- 🆓💰 [BulkTranscripts](https://github.com/pratie/bulktranscripts-mcp) — Enumerate a YouTube channel's uploads, search inside a channel by topic, and pull full transcripts as clean text. `get_latest_videos` is unmetered, so a subject's channel can be polled for new uploads and credits spent only on what appears. Hosted, 7 tools, no signup: 30 free credits per public IP — searches and listings cost a credit too, and a shared or NAT address may arrive with the allowance already spent. One-time credit packs after that. MCP: https://bulktranscripts.co/mcp
+- 🆓💰 [BulkTranscripts](https://github.com/pratie/bulktranscripts-mcp) — YouTube channel uploads, in-channel topic search, and full transcripts as clean text. `get_latest_videos` is unmetered — poll it to watch a subject's channel and spend credits only on what is new. Hosted, 7 tools, no signup; 30 free credits shared per public IP, then one-time packs. MCP: https://bulktranscripts.co/mcp
 
 ## Network Scanning
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Legend: 📦 Open Source &nbsp;&middot;&nbsp; 🆓 Free / Has Free Tier &nbsp;&m
 - 📦💰 [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) — X (Twitter) data extraction and automation with 40+ REST API endpoints, real-time account monitoring, and trending topics. MCP server with API key auth.
 - 📦🆓 [OSINT Tools MCP](https://github.com/frishtik/osint-tools-mcp-server) — Wraps seven classic OSINT CLIs behind one server: Sherlock and Blackbird (usernames), Maigret, Holehe (email), GHunt (Google accounts), theHarvester (domains) and SpiderFoot. Python, installs the underlying tools itself.
 - 📦🆓 [LinkedIn MCP](https://github.com/eliasbiondo/linkedin-mcp-server) — Search LinkedIn people, companies and jobs, and pull structured profile, company and post data. Uses your own session cookie; no API key.
-- 🆓💰 [BulkTranscripts](https://github.com/pratie/bulktranscripts-mcp) — Enumerate a YouTube channel's uploads, search inside a channel by topic, and pull full transcripts as clean text for analysis; new-upload tracking lets a subject's channel be monitored over time. Hosted, keyless on the free tier (30 transcripts per IP), 7 tools. MCP: https://bulktranscripts.co/mcp
+- 🆓💰 [BulkTranscripts](https://github.com/pratie/bulktranscripts-mcp) — Enumerate a YouTube channel's uploads, search inside a channel by topic, and pull full transcripts as clean text. `get_latest_videos` is unmetered, so a subject's channel can be polled for new uploads and credits spent only on what appears. Hosted, 7 tools, no signup: 30 free credits per public IP — searches and listings cost a credit too, and a shared or NAT address may arrive with the allowance already spent. One-time credit packs after that. MCP: https://bulktranscripts.co/mcp
 
 ## Network Scanning
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Legend: 📦 Open Source &nbsp;&middot;&nbsp; 🆓 Free / Has Free Tier &nbsp;&m
 - 📦💰 [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) — X (Twitter) data extraction and automation with 40+ REST API endpoints, real-time account monitoring, and trending topics. MCP server with API key auth.
 - 📦🆓 [OSINT Tools MCP](https://github.com/frishtik/osint-tools-mcp-server) — Wraps seven classic OSINT CLIs behind one server: Sherlock and Blackbird (usernames), Maigret, Holehe (email), GHunt (Google accounts), theHarvester (domains) and SpiderFoot. Python, installs the underlying tools itself.
 - 📦🆓 [LinkedIn MCP](https://github.com/eliasbiondo/linkedin-mcp-server) — Search LinkedIn people, companies and jobs, and pull structured profile, company and post data. Uses your own session cookie; no API key.
+- 🆓💰 [BulkTranscripts](https://github.com/pratie/bulktranscripts-mcp) — Enumerate a YouTube channel's uploads, search inside a channel by topic, and pull full transcripts as clean text for analysis; new-upload tracking lets a subject's channel be monitored over time. Hosted, keyless on the free tier (30 transcripts per IP), 7 tools. MCP: https://bulktranscripts.co/mcp
 
 ## Network Scanning
 


### PR DESCRIPTION
Adds BulkTranscripts, a hosted YouTube MCP server, to the SOCMINT section.

**Investigative use:** enumerate a subject's or organisation's YouTube channel (up to 1,000 videos), search within that channel by topic, pull full transcripts as clean text for analysis, and monitor the channel for new uploads over time. Same use case as the existing LinkedIn/AnySite entries, applied to YouTube.

**Verification (per CONTRIBUTING):**

`initialize` handshake responds:

```
$ curl -sS -X POST https://bulktranscripts.co/mcp \
    -H 'Content-Type: application/json' \
    -H 'Accept: application/json, text/event-stream' \
    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"verify","version":"1.0"}}}'

{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"tools":{}},"serverInfo":{"name":"bulktranscripts","title":"BulkTranscripts — YouTube transcripts for AI","version":"1.0.0"}}}
```

`tools/list` returns exactly the 7 claimed tools: `get_transcript`, `get_transcripts`, `search_youtube`, `search_channel`, `get_channel_videos`, `get_playlist_videos`, `get_latest_videos`. No API key needed to reproduce either call.

**Emoji:** 🆓💰 only. Deliberately not 📦 — the linked repo holds the manifest and docs, the extraction service itself is closed-source, so claiming open-source would be inaccurate.

Also published to the official MCP Registry as `co.bulktranscripts/youtube`. One line, existing section, existing format.

**Disclosure:** I build and run BulkTranscripts. It is a paid service with a free tier, not a community project.
