### PR TITLE
Cap entry descriptions at 400 characters

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,12 @@ If in doubt, ask: would an investigator or a security researcher doing recon use
 
 5. **Description is accurate and sells the actual tool**, not the company behind it. One or two sentences on what it does and what's required to use it (API key, free tier limits) is enough.
 
+6. **Keep it short.** The description — everything after the em dash — must stay under 400 characters, and ideally around 250. The median entry in the list is 225. Anything longer is documentation rather than an index entry: caveats, pricing tiers and per-tool costs belong in your own README, with a link to it. Only the text counts, so a long URL costs you nothing.
+
+   ```bash
+   grep -oP '^- \S+ \[[^\]]+\]\([^)]+\)\s+—\s+\K.*' README.md | awk 'length>400{print length": "$0}'
+   ```
+
 ## Process
 
 - Small, single-entry PRs only — one server per PR.


### PR DESCRIPTION
"One or two sentences" is not a limit — it's a suggestion, and the list has been drifting past it. Current spread of the 49 descriptions (text after the em dash, link excluded):

| | chars |
|---|---|
| min | 65 |
| median | **225** |
| p75 | 368 |
| p90 | 413 |
| max | 748 |

This adds a hard cap of 400 with a target of 250, and a one-line grep so it's checkable rather than argued about. The cap is deliberately loose — half the list is already under 250, so it only bites on entries that have turned into documentation.

Nine entries are currently over: ContrastAPI (748), DataNexus MCP (493), World Intel MCP (491), Clearfront (484), Sift (413), Fylings (412), OpenRegistry (410), ScanMalware (410), Satellite MCP (409). Five of those are over by ten characters or so. Not touching them here — that's a separate cleanup.
